### PR TITLE
Fix Nullable Types

### DIFF
--- a/VxFormGenerator/Components/Bootstrap/BootstrapInputCheckbox.cs
+++ b/VxFormGenerator/Components/Bootstrap/BootstrapInputCheckbox.cs
@@ -3,7 +3,7 @@ using VxFormGenerator.Components.Plain;
 
 namespace VxFormGenerator.Components.Bootstrap
 {
-    public class BootstrapInputCheckbox : VxInputCheckbox
+    public class BootstrapInputCheckbox <TValue>: VxInputCheckbox<TValue>
     {
         public BootstrapInputCheckbox()
         {

--- a/VxFormGenerator/Components/Bootstrap/BootstrapInputCheckboxMultiple.cs
+++ b/VxFormGenerator/Components/Bootstrap/BootstrapInputCheckboxMultiple.cs
@@ -20,7 +20,7 @@ namespace VxFormGenerator.Components.Bootstrap
          object dataContext,
          string fieldIdentifier)
         {
-            RenderChildren(builder, index, dataContext, fieldIdentifier, typeof(BootstrapInputCheckbox));
+            RenderChildren(builder, index, dataContext, fieldIdentifier, typeof(BootstrapInputCheckbox<TValue>));
         }
 
     }

--- a/VxFormGenerator/Components/Plain/InputCheckboxMultiple.razor.cs
+++ b/VxFormGenerator/Components/Plain/InputCheckboxMultiple.razor.cs
@@ -16,13 +16,13 @@ namespace VxFormGenerator.Components.Plain
         /// </summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
 
-        List<VxInputCheckboxComponent> Checkboxes = new List<VxInputCheckboxComponent>();
+        List<VxInputCheckboxComponent<T>> Checkboxes = new List<VxInputCheckboxComponent<T>>();
 
         /// <inheritdoc />
         protected override bool TryParseValueFromString(string value, out T result, out string validationErrorMessage)
             => throw new NotImplementedException($"This component does not parse string inputs. Bind to the '{nameof(CurrentValue)}' property, not '{nameof(CurrentValueAsString)}'.");
 
-        internal void RegisterCheckbox(VxInputCheckboxComponent checkbox)
+        internal void RegisterCheckbox(VxInputCheckboxComponent<T> checkbox)
         {
             Checkboxes.Add(checkbox);
 

--- a/VxFormGenerator/Components/Plain/InputCheckboxMultipleWithChildren.cs
+++ b/VxFormGenerator/Components/Plain/InputCheckboxMultipleWithChildren.cs
@@ -17,7 +17,7 @@ namespace VxFormGenerator.Components.Plain
             object dataContext,
             string fieldIdentifier)
         {
-            RenderChildren(builder, index, dataContext, fieldIdentifier, typeof(VxInputCheckbox));
+            RenderChildren(builder, index, dataContext, fieldIdentifier, typeof(VxInputCheckbox<TValue>));
         }
 
         internal static void RenderChildren(RenderTreeBuilder builder,
@@ -41,7 +41,7 @@ namespace VxFormGenerator.Components.Plain
                        _builder.OpenComponent(_index++, typeOfChildToRender);
 
                        // Set the value of the enum as a value and key parameter
-                       _builder.AddAttribute(_index++, nameof(VxInputCheckbox.Value), val.Value);
+                       _builder.AddAttribute(_index++, nameof(VxInputCheckbox<TValue>.Value), val.Value);
 
                        // Create the handler for ValueChanged. This wil update the model instance with the input
                        _builder.AddAttribute(_index++, nameof(ValueChanged),
@@ -56,7 +56,7 @@ namespace VxFormGenerator.Components.Plain
                        var lamb = Expression.Lambda<Func<bool>>(exp);
                        _builder.AddAttribute(_index++, nameof(InputBase<bool>.ValueExpression), lamb);
 
-                       _builder.AddAttribute(_index++, nameof(VxInputCheckbox.Label), val.Key);
+                       _builder.AddAttribute(_index++, nameof(VxInputCheckbox<TValue>.Label), val.Key);
 
                        // Close the component
                        _builder.CloseComponent();

--- a/VxFormGenerator/Components/Plain/VxInputCheckbox.razor
+++ b/VxFormGenerator/Components/Plain/VxInputCheckbox.razor
@@ -1,4 +1,5 @@
-﻿@inherits VxFormGenerator.Components.Plain.VxInputCheckboxComponent;
+﻿@typeparam TValue
+@inherits VxFormGenerator.Components.Plain.VxInputCheckboxComponent<TValue>;
 
 <div class="@ContainerCss">
     <input type="checkbox" class="@CssClass" id="@Id" @bind="CurrentValue">

--- a/VxFormGenerator/Components/Plain/VxInputCheckbox.razor.cs
+++ b/VxFormGenerator/Components/Plain/VxInputCheckbox.razor.cs
@@ -5,14 +5,14 @@ using System.Reflection;
 
 namespace VxFormGenerator.Components.Plain
 {
-    public class VxInputCheckboxComponent : VxInputBase<bool>, IDisposable
+    public class VxInputCheckboxComponent<TValue> : VxInputBase<TValue>, IDisposable
     {
         [Parameter] public string Label { get; set; }
         [Parameter] public string LabelCss { get; set; }
         [Parameter] public string ContainerCss { get; set; }
 
 
-        protected override bool TryParseValueFromString(string value, out bool result, out string validationErrorMessage)
+        protected override bool TryParseValueFromString(string value, out TValue result, out string validationErrorMessage)
            => throw new NotImplementedException($"This component does not parse string inputs. Bind to the '{nameof(CurrentValue)}' property, not '{nameof(CurrentValueAsString)}'.");
 
 


### PR DESCRIPTION
my apologies if i messed anything up this is my first pull request ever.
this is related to issue #3 

with this fix we can now have this declaration with no visible errors and the form is behaving in a similar way to non nullable types:

 ```
       public FormGeneratorComponentsRepository BootstrapFormMapping = new FormGeneratorComponentsRepository(
            new Dictionary<string, Type>()
            {
                {typeof(string                                              ).ToString(), typeof(BootstrapInputText)                },

                {typeof(DateTime?                                           ).ToString(), typeof(InputDate<DateTime?>)                       },
                {typeof(bool?                                               ).ToString(), typeof(BootstrapInputCheckbox<bool?>)            },
                {typeof(decimal?                                            ).ToString(), typeof(BootstrapInputNumber<decimal?>)            },
                {typeof(Int32?                                              ).ToString(), typeof(BootstrapInputNumber<Int32?>)            },
                {typeof(Int64?                                              ).ToString(), typeof(BootstrapInputNumber<Int64?>)            },
                {typeof(float?                                              ).ToString(), typeof(BootstrapInputNumber<float?>)            },
                {typeof(double?                                             ).ToString(), typeof(BootstrapInputNumber<double?>)            },

            }, null, typeof(BootstrapFormElement<>));
```