### PR TITLE
Feature - Add support for floating point types

### DIFF
--- a/VxFormGenerator.Components.Bootstrap/VxBootstrapFormComponentsRepository.cs
+++ b/VxFormGenerator.Components.Bootstrap/VxBootstrapFormComponentsRepository.cs
@@ -24,6 +24,7 @@ namespace VxFormGenerator.Repository.Bootstrap
                     { typeof(Enum),            typeof(BootstrapInputSelectWithOptions<>) },
                     { typeof(ValueReferences), typeof(BootstrapInputCheckboxMultiple<>) },
                     { typeof(decimal),         typeof(InputNumber<>) },
+                    { typeof(System.Single),   typeof(InputNumber<>) },
                     { typeof(int),             typeof(InputNumber<>) },
                     { typeof(VxColor),         typeof(InputColor) }
                   };

--- a/VxFormGenerator.Components.Plain/VxComponentsRepository.cs
+++ b/VxFormGenerator.Components.Plain/VxComponentsRepository.cs
@@ -15,19 +15,20 @@ namespace VxFormGenerator.Repository.Plain
 
             _ComponentDict = new Dictionary<Type, Type>()
                   {
-                        {typeof(string), typeof(VxInputText) },
-                        {typeof(DateTime), typeof(InputDate<>) },
-                        {typeof(int), typeof(InputNumber<>) },
-                        {typeof(bool), typeof(VxInputCheckbox) },
-                        {typeof(Enum), typeof(InputSelectWithOptions<>) },
-                        {typeof(ValueReferences), typeof(InputCheckboxMultiple<>) },
-                        {typeof(decimal), typeof(InputNumber<>) },
-                        {typeof(VxColor), typeof(InputColor) }
+                        {typeof(string),            typeof(VxInputText) },
+                        {typeof(DateTime),          typeof(InputDate<>) },
+                        {typeof(int),               typeof(InputNumber<>) },
+                        {typeof(bool),              typeof(VxInputCheckbox) },
+                        {typeof(Enum),              typeof(InputSelectWithOptions<>) },
+                        {typeof(ValueReferences),   typeof(InputCheckboxMultiple<>) },
+                        {typeof(decimal),           typeof(InputNumber<>) },
+                        { typeof(System.Single),    typeof(InputNumber<>) },
+                        {typeof(VxColor),           typeof(InputColor) }
                   };
             _DefaultComponent = null;
-         
-            
+
+
         }
-     
+
     }
 }


### PR DESCRIPTION
Using properties like float or float?, its not rendering the form.
By adding System.Single as a new type to VsBootstrapRepository dictionary this will be fixed

Some info:
https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/floating-point-numeric-types