### PR TITLE
Added tooltip component for Description property in Display Attribute

### DIFF
--- a/VxFormGenerator.Components.Plain/Render/FormElement.razor
+++ b/VxFormGenerator.Components.Plain/Render/FormElement.razor
@@ -1,12 +1,20 @@
 ﻿@namespace VxFormGenerator.Form
-
+@using VxFormGenerator.Core.Components
 @typeparam TFormElement
 @inherits  FormElementComponent<TFormElement>
 
 <div>
     @if (!string.IsNullOrWhiteSpace(FormColumnDefinition.RenderOptions.Label) && FormColumnDefinition.RenderOptions.ShowLabel)
     {
-        <label class="col-form-label" for="@Id">@FormColumnDefinition.RenderOptions.Label</label>
+        <label class="col-form-label" for="@Id">
+            <span>@FormColumnDefinition.RenderOptions.Label</span>
+            @if (!String.IsNullOrEmpty(FormColumnDefinition.RenderOptions.Description))
+            {
+                <Tooltip Text="@FormColumnDefinition.RenderOptions.Description">
+                    <div>(<i class="oi oi-info small"></i>)</div>
+                </Tooltip>
+            }
+        </label>
     }
 
     @CreateComponent()

--- a/VxFormGenerator.Components.Plain/Render/VxFormRow.razor
+++ b/VxFormGenerator.Components.Plain/Render/VxFormRow.razor
@@ -1,12 +1,22 @@
 ﻿@namespace VxFormGenerator.Render.Plain
 @inherits VxFormGenerator.Render.Plain.VxFormRowComponent
-
-
+@using VxFormGenerator.Core.Components
 
 <div class="form-row">
     @if (FormRowDefinition.Label != null)
     {
-        <label class="col-sm-3 col-form-label">@FormRowDefinition.Label</label>
+        <label class="col-sm-3 col-form-label">
+            <span>
+                @FormRowDefinition.Label
+            </span>
+            @if (!String.IsNullOrEmpty(FormRowDefinition.Description))
+            {
+                <Tooltip Text="@FormRowDefinition.Description">
+                    <div>(<i class="oi oi-info small"></i>)</div>
+                </Tooltip>
+            }
+
+        </label>
     }
 
     @foreach (var column in FormRowDefinition.Columns)
@@ -16,4 +26,3 @@
         </VxFormGenerator.Render.Plain.VxFormColumn>
     }
 </div>
-

--- a/VxFormGenerator.Core/Components/Tooltip.razor
+++ b/VxFormGenerator.Core/Components/Tooltip.razor
@@ -1,0 +1,48 @@
+﻿<style>
+    .tooltip-wrapper {
+        position: relative;
+        display: inline-block;
+        cursor: help;
+    }
+        
+    .tooltip-text {
+        visibility: hidden;
+        position: absolute;
+        width: 120px;
+        bottom: 100%;
+        left: 50%;
+        margin-left: -60px;
+        background-color: #363636;
+        color: #fff;
+        text-align: center;
+        padding: 5px 0;
+        border-radius: 6px;
+        z-index: 1;
+        font-size: 12px;
+    }
+        
+    .tooltip-text::after {
+        content: "";
+        position: absolute;
+        top: 100%;
+        left: 50%;
+        margin-left: -5px;
+        border-width: 5px;
+        border-style: solid;
+        border-color: #555 transparent transparent transparent;
+    }
+        
+    .tooltip-wrapper:hover span {
+        visibility: visible;
+    }
+</style>
+
+<div class="tooltip-wrapper">
+    <span class="tooltip-text">@Text</span>
+    @ChildContent
+</div>
+ 
+@code {
+    [Parameter] public RenderFragment ChildContent { get; set; }
+    [Parameter] public string Text { get; set; }
+}

--- a/VxFormGenerator.Core/Layout/VxFormGroup.cs
+++ b/VxFormGenerator.Core/Layout/VxFormGroup.cs
@@ -8,10 +8,8 @@ using System.Text;
 
 namespace VxFormGenerator.Core.Layout
 {
-
     public class VxFormGroup
     {
-
         public string Label { get; set; }
 
         public string Id { get; set; }
@@ -52,7 +50,8 @@ namespace VxFormGenerator.Core.Layout
             return rootGroup;
         }
 
-        internal static void Add(string fieldIdentifier, VxFormGroup group, object modelInstance, VxFormLayoutOptions options)
+        internal static void Add(string fieldIdentifier, VxFormGroup group, object modelInstance,
+            VxFormLayoutOptions options)
         {
             // TODO: EXPANDO switch
             var prop = modelInstance.GetType().GetProperty(fieldIdentifier);
@@ -74,8 +73,10 @@ namespace VxFormGenerator.Core.Layout
 
             if (foundRow == null)
             {
-                foundRow = VxFormRow.Create(layoutAttr, allRowLayoutAttributes.Find(x => x.Id == layoutAttr.RowId), options);
-                group.Rows.Add(foundRow); ;
+                foundRow = VxFormRow.Create(layoutAttr, allRowLayoutAttributes.Find(x => x.Id == layoutAttr.RowId),
+                    options);
+                group.Rows.Add(foundRow);
+                ;
             }
 
             var formColumn = VxFormElementDefinition.Create(fieldIdentifier, layoutAttr, modelInstance, options);
@@ -85,7 +86,18 @@ namespace VxFormGenerator.Core.Layout
             if (options.LabelOrientation == LabelOrientation.LEFT && foundRow.RowLayoutAttribute?.Label == null)
                 foundRow.Label = string.Join(", ", foundRow.Columns.ConvertAll(x => x.RenderOptions.Label));
 
+            //If row description hasn't already been set
+            //Merge all row properties descriptions into a string and set row description if at least one found
+            if (foundRow.RowLayoutAttribute == null)
+            {
+                var descriptions = foundRow.Columns.ConvertAll(x => x.RenderOptions.Description);
+                descriptions.RemoveAll(x => x == null);
+                var description = string.Join(", ", descriptions);
+                if (!String.IsNullOrEmpty(description))
+                    foundRow.Description = description;
+            }
         }
+
         /// <summary>
         /// Get the values of built-in attributes like <see cref="DisplayAttribute"/> and patch it to a <see cref="VxFormLayoutAttribute"/>
         /// </summary>
@@ -94,12 +106,13 @@ namespace VxFormGenerator.Core.Layout
         private static void PatchLayoutWithBuiltInAttributes(VxFormElementLayoutAttribute layoutAttr, PropertyInfo prop)
         {
             var displayAttribute = prop
-                   .GetCustomAttributes(typeof(DisplayAttribute), false)
-                   .FirstOrDefault() as DisplayAttribute;
+                .GetCustomAttributes(typeof(DisplayAttribute), false)
+                .FirstOrDefault() as DisplayAttribute;
 
             if (displayAttribute != null)
             {
                 layoutAttr.Label = displayAttribute.GetName();
+                layoutAttr.Description = displayAttribute.GetDescription();
                 layoutAttr.Order = displayAttribute.GetOrder().GetValueOrDefault();
             }
         }
@@ -115,8 +128,8 @@ namespace VxFormGenerator.Core.Layout
             else
             {
                 var prop = modelInstance
-                .GetType()
-                .GetProperty(fieldIdentifier);
+                    .GetType()
+                    .GetProperty(fieldIdentifier);
 
                 var displayAttribute = prop
                     .GetCustomAttributes(typeof(DisplayAttribute), false)
@@ -124,7 +137,6 @@ namespace VxFormGenerator.Core.Layout
 
                 return displayAttribute != null ? displayAttribute.Name : fieldIdentifier;
             }
-
         }
 
         internal static VxFormGroup Create()

--- a/VxFormGenerator.Core/Layout/VxFormLayout.cs
+++ b/VxFormGenerator.Core/Layout/VxFormLayout.cs
@@ -34,6 +34,7 @@ namespace VxFormGenerator.Core.Layout
     public class VxFormRowLayoutAttribute : Attribute
     {
         public string Label { get; set; }
+        public string Description { get; set; }
         public int Order { get; set; }
         public int Id { get; set; }
     }

--- a/VxFormGenerator.Core/Layout/VxFormRow.cs
+++ b/VxFormGenerator.Core/Layout/VxFormRow.cs
@@ -8,6 +8,7 @@ namespace VxFormGenerator.Core.Layout
     {
 
         public string Label { get; set; }
+        public string Description { get; set; }
         public string Id { get; set; }
 
         public List<VxFormElementDefinition> Columns { get; set; } = new List<VxFormElementDefinition>();
@@ -36,6 +37,11 @@ namespace VxFormGenerator.Core.Layout
 
             if (options.LabelOrientation == LabelOrientation.LEFT && output.RowLayoutAttribute?.Label != null)
                 output.Label = vxFormRowLayoutAttribute.Label;
+            // If row has Description attribute set - pass it to output.Description
+            if (vxFormRowLayoutAttribute is {Description: { }})
+            {
+                output.Description = vxFormRowLayoutAttribute.Description;
+            }
 
             return output;
         }

--- a/VxFormGeneratorDemoData/Address.cs
+++ b/VxFormGeneratorDemoData/Address.cs
@@ -4,19 +4,19 @@ using VxFormGenerator.Core.Layout;
 namespace VxFormGeneratorDemoData
 {
     // Add label to row 2
-    [VxFormRowLayout(Id = 2, Label = "Adress")]
+    [VxFormRowLayout(Id = 2, Label = "Address", Description = "This is an address")]
     public class AddressViewModel
     {
-        [Display(Name = "Firstname")]
+        [Display(Name = "Firstname", Description = "This is a first name")]
         // Add element to row 1 with automatic width based on number of items in a row
         [VxFormElementLayout(RowId = 1)]
         public string SurName { get; set; }
         // Add element to row 1 with automatic width based on number of items in a row and define a placeholder
         [VxFormElementLayout(RowId = 1, Placeholder = "Your Lastname")]
-        [Display(Name = "Lastname")]
+        [Display(Name = "Lastname", Description = "This is a last name")]
         public string LastName { get; set; }
 
-        [Display(Name = "Street")]
+        [Display(Name = "Street",Description = "This is a street")]
         // Add element to row 2 and set the width to 9 of 12 columns
         [VxFormElementLayout(RowId = 2, ColSpan = 9)]
         [MinLength(5)]

--- a/VxFormGeneratorDemoData/FeedingSession.cs
+++ b/VxFormGeneratorDemoData/FeedingSession.cs
@@ -8,7 +8,7 @@ namespace VxFormGeneratorDemoData
 {
     public class FeedingSession
     {
-        [Display(Name = "Kind of food")]
+        [Display(Name = "Kind of food", Description = "This is a food kind")]
         public FoodKind KindOfFood { get; set; }
         
         [Display(Name = "Note")]


### PR DESCRIPTION
Added a tooltip component which appears by the label when Description property in Display attribute is set.
After hovering an icon it displays a text from Description.

**A Description for a property:**
![image](https://user-images.githubusercontent.com/44945134/165955743-71aec44a-ab09-44c0-af9e-3cb77bf19ab9.png)
![image](https://user-images.githubusercontent.com/44945134/165955644-8b4d35cc-7941-40b2-b72a-d073c5f7e286.png)

**A Description for a whole row (works with either TOP or LEFT alignment):**
![image](https://user-images.githubusercontent.com/44945134/165957270-3f502620-d6c0-4291-8590-f0bbb03e8b87.png)
![image](https://user-images.githubusercontent.com/44945134/165956739-f029e9fa-304a-4cc1-8b42-cd118048923e.png)
![image](https://user-images.githubusercontent.com/44945134/165956768-5e84daf7-93c9-4fc6-858d-c3b1be4956a6.png)
