### PR TITLE
Fix generated form label associations

### DIFF
--- a/VxFormGenerator.Components.Bootstrap/Render/BootstrapFormElement.razor
+++ b/VxFormGenerator.Components.Bootstrap/Render/BootstrapFormElement.razor
@@ -13,7 +13,7 @@ else
     <div class="@CssClass">
         @if (!string.IsNullOrWhiteSpace(FormColumnDefinition.RenderOptions.Label) && FormColumnDefinition.RenderOptions.ShowLabel)
         {
-            <label class="col-form-label" for="@Id">@FormColumnDefinition.RenderOptions.Label</label>
+            <label class="col-form-label" for="@ElementId">@FormColumnDefinition.RenderOptions.Label</label>
         }
 
         @CreateComponent()

--- a/VxFormGenerator.Components.Plain/Render/FormElement.razor
+++ b/VxFormGenerator.Components.Plain/Render/FormElement.razor
@@ -12,7 +12,7 @@ else
     <div>
         @if (!string.IsNullOrWhiteSpace(FormColumnDefinition.RenderOptions.Label) && FormColumnDefinition.RenderOptions.ShowLabel)
         {
-            <label class="col-form-label" for="@Id">@FormColumnDefinition.RenderOptions.Label</label>
+            <label class="col-form-label" for="@ElementId">@FormColumnDefinition.RenderOptions.Label</label>
         }
 
         @CreateComponent()

--- a/VxFormGenerator.Components.Plain/Render/VxFormColumn.razor
+++ b/VxFormGenerator.Components.Plain/Render/VxFormColumn.razor
@@ -4,7 +4,7 @@
 <div class="@CssClass" style="@Style">
     @if (ShowLeftFieldLabel)
     {
-        <label class="vx-form-left-field-label col-form-label">@FormColumnDefinition.RenderOptions.Label</label>
+        <label class="vx-form-left-field-label col-form-label" for="@FormColumnDefinition.Name">@FormColumnDefinition.RenderOptions.Label</label>
     }
 
     @CreateFormElement()

--- a/VxFormGenerator.Core.Tests/RenderFormElementsTemplateTests.cs
+++ b/VxFormGenerator.Core.Tests/RenderFormElementsTemplateTests.cs
@@ -20,7 +20,9 @@ namespace VxFormGenerator.Core.Tests
             var surnameField = component.Find(".custom-field[data-field-name='SurName']");
 
             Assert.Equal("Firstname", surnameField.QuerySelector(".custom-label").TextContent);
-            Assert.NotNull(surnameField.QuerySelector(".custom-input input"));
+            var input = surnameField.QuerySelector(".custom-input input");
+            Assert.NotNull(input);
+            Assert.Equal(surnameField.QuerySelector(".custom-label").GetAttribute("for"), input.GetAttribute("id"));
             Assert.NotNull(surnameField.QuerySelector(".custom-validation"));
         }
 
@@ -46,6 +48,12 @@ namespace VxFormGenerator.Core.Tests
             Assert.Contains(component.FindAll(".vx-form-left-field-label"), label => label.TextContent == "Lastname");
             Assert.DoesNotContain(component.FindAll(".vx-form-left-field-label"), label => label.TextContent == "Street");
             Assert.DoesNotContain(component.FindAll(".vx-form-left-field-label"), label => label.TextContent == "Number");
+
+            var firstNameLabel = component.Find(".vx-form-left-field-label[for='SurName']");
+            var firstNameInput = component.Find("input#SurName");
+
+            Assert.Equal("Firstname", firstNameLabel.TextContent);
+            Assert.NotNull(firstNameInput);
         }
     }
 }

--- a/VxFormGenerator.Core/FormElementBase.cs
+++ b/VxFormGenerator.Core/FormElementBase.cs
@@ -58,6 +58,8 @@ namespace VxFormGenerator.Core
 
         [CascadingParameter] public RenderFragment<VxFormFieldTemplateContext> FieldTemplate { get; set; }
 
+        protected string ElementId => string.IsNullOrWhiteSpace(Id) ? FormColumnDefinition.Name : Id;
+
 
         protected override void OnInitialized()
         {
@@ -104,7 +106,7 @@ namespace VxFormGenerator.Core
             return new VxFormFieldTemplateContext
             {
                 Name = FormColumnDefinition.Name,
-                Id = string.IsNullOrWhiteSpace(Id) ? FormColumnDefinition.Name : Id,
+                Id = ElementId,
                 Label = FormColumnDefinition.RenderOptions.Label,
                 ShowLabel = FormColumnDefinition.RenderOptions.ShowLabel,
                 FieldDefinition = FormColumnDefinition,
@@ -155,6 +157,8 @@ namespace VxFormGenerator.Core
 
             if (FormColumnDefinition.RenderOptions.Placeholder != null)
                 builder.AddAttribute(treeIndex++, "placeholder", FormColumnDefinition.RenderOptions.Placeholder);
+
+            builder.AddAttribute(treeIndex++, "id", ElementId);
 
             // Set the class for the the formelement.
             builder.AddAttribute(treeIndex++, "class", GetDefaultFieldClasses(Activator.CreateInstance(elementType) as InputBase<TFormElement>));


### PR DESCRIPTION
Fixes #20.

## Changes
- Add a stable `id` attribute to generated input components.
- Point default Plain and Bootstrap labels at the generated input id.
- Include the same id in field template context.
- Add regression coverage for field-template and left-label associations.

## Validation
- Not run: this runtime does not have `dotnet` on PATH and the documented `/workspace/.dotnet/dotnet` path is absent.