### PR TITLE
Add Bulma and Tailwind renderer packages

### DIFF
--- a/FormGeneratorDemo.sln
+++ b/FormGeneratorDemo.sln
@@ -9,6 +9,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VxFormGenerator.Core", "VxF
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VxFormGenerator.Components.Bootstrap", "VxFormGenerator.Components.Bootstrap\VxFormGenerator.Components.Bootstrap.csproj", "{23AB5CD5-8FB4-43A5-9B7B-1E704C1A3909}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VxFormGenerator.Components.Bulma", "VxFormGenerator.Components.Bulma\VxFormGenerator.Components.Bulma.csproj", "{7D2E174F-A7EC-44B0-BBDE-05213D32544D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VxFormGenerator.Components.Tailwind", "VxFormGenerator.Components.Tailwind\VxFormGenerator.Components.Tailwind.csproj", "{9542DC6A-B03D-4F73-90E6-A4D0E217B278}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VxFormGenerator.Components.Plain", "VxFormGenerator.Components.Plain\VxFormGenerator.Components.Plain.csproj", "{5BB684AC-3B47-4492-9AE6-8FA93567E53A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{793D7184-2846-4E6D-A4C4-7B93D5EB276E}"
@@ -58,6 +62,14 @@ Global
 		{23AB5CD5-8FB4-43A5-9B7B-1E704C1A3909}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{23AB5CD5-8FB4-43A5-9B7B-1E704C1A3909}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{23AB5CD5-8FB4-43A5-9B7B-1E704C1A3909}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7D2E174F-A7EC-44B0-BBDE-05213D32544D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7D2E174F-A7EC-44B0-BBDE-05213D32544D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7D2E174F-A7EC-44B0-BBDE-05213D32544D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7D2E174F-A7EC-44B0-BBDE-05213D32544D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9542DC6A-B03D-4F73-90E6-A4D0E217B278}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9542DC6A-B03D-4F73-90E6-A4D0E217B278}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9542DC6A-B03D-4F73-90E6-A4D0E217B278}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9542DC6A-B03D-4F73-90E6-A4D0E217B278}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5BB684AC-3B47-4492-9AE6-8FA93567E53A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5BB684AC-3B47-4492-9AE6-8FA93567E53A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5BB684AC-3B47-4492-9AE6-8FA93567E53A}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/VxFormGenerator.Components.Bulma/Components/BulmaInputCheckbox.cs
+++ b/VxFormGenerator.Components.Bulma/Components/BulmaInputCheckbox.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using VxFormGenerator.Form.Components.Plain;
+
+namespace VxFormGenerator.Form.Components.Bulma
+{
+    public class BulmaInputCheckbox : VxInputCheckbox
+    {
+        public BulmaInputCheckbox()
+        {
+            ContainerCss = "control";
+            AdditionalAttributes = new Dictionary<string, object>() { { "class", "checkbox" } };
+            LabelCss = "checkbox";
+        }
+    }
+}

--- a/VxFormGenerator.Components.Bulma/Components/BulmaInputCheckboxMultiple.cs
+++ b/VxFormGenerator.Components.Bulma/Components/BulmaInputCheckboxMultiple.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Components.Rendering;
+using System.Collections.Generic;
+using VxFormGenerator.Core;
+using VxFormGenerator.Form.Components.Plain;
+
+namespace VxFormGenerator.Form.Components.Bulma
+{
+    public class BulmaInputCheckboxMultiple<TValue> : InputCheckboxMultipleWithChildren<TValue>, IRenderChildren
+    {
+        public BulmaInputCheckboxMultiple()
+        {
+            AdditionalAttributes = new Dictionary<string, object>() { { "class", "checkbox" } };
+        }
+
+        public new static void RenderChildren(RenderTreeBuilder builder,
+         int index,
+         object dataContext,
+         string fieldIdentifier)
+        {
+            RenderChildren(builder, index, dataContext, fieldIdentifier, typeof(BulmaInputCheckbox));
+        }
+    }
+}

--- a/VxFormGenerator.Components.Bulma/Components/BulmaInputSelectWithOptions.cs
+++ b/VxFormGenerator.Components.Bulma/Components/BulmaInputSelectWithOptions.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using VxFormGenerator.Form.Components.Plain;
+
+namespace VxFormGenerator.Form.Components.Bulma
+{
+    public class BulmaInputSelectWithOptions<TValue> : InputSelectWithOptions<TValue>
+    {
+        public BulmaInputSelectWithOptions()
+        {
+            AdditionalAttributes = new Dictionary<string, object>() { { "class", "select is-fullwidth" } };
+        }
+    }
+}

--- a/VxFormGenerator.Components.Bulma/Render/BulmaFormElement.razor
+++ b/VxFormGenerator.Components.Bulma/Render/BulmaFormElement.razor
@@ -1,0 +1,25 @@
+@namespace VxFormGenerator.Render.Bulma
+
+@typeparam TFormElement
+@inherits BulmaFormElementComponent<TFormElement>
+
+@if (FieldTemplate != null)
+{
+    @FieldTemplate(CreateFieldTemplateContext("help is-danger"))
+}
+else
+{
+    <div class="@CssClass">
+        @if (!string.IsNullOrWhiteSpace(FormColumnDefinition.RenderOptions.Label) && FormColumnDefinition.RenderOptions.ShowLabel)
+        {
+            <label class="label" for="@Id">@FormColumnDefinition.RenderOptions.Label</label>
+        }
+
+        <div class="control">
+            @CreateComponent()
+        </div>
+
+        <VxFormGenerator.Core.Validation.VxValidationMessage For="@ValueExpression" Class="help is-danger">
+        </VxFormGenerator.Core.Validation.VxValidationMessage>
+    </div>
+}

--- a/VxFormGenerator.Components.Bulma/Render/BulmaFormElement.razor.cs
+++ b/VxFormGenerator.Components.Bulma/Render/BulmaFormElement.razor.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using VxFormGenerator.Core;
+
+namespace VxFormGenerator.Render.Bulma
+{
+    public class BulmaFormElementComponent<TFormElement> : FormElementBase<TFormElement>
+    {
+        protected override void OnParametersSet()
+        {
+            base.OnParametersSet();
+
+            DefaultFieldClasses = new List<string>() { "input" };
+            CssClasses = new List<string>() { "field" };
+        }
+    }
+}

--- a/VxFormGenerator.Components.Bulma/VxBulmaFormComponentsRepository.cs
+++ b/VxFormGenerator.Components.Bulma/VxBulmaFormComponentsRepository.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Components.Forms;
+using System;
+using System.Collections.Generic;
+using VxFormGenerator.Core;
+using VxFormGenerator.Core.Repository;
+using VxFormGenerator.Form.Components.Bulma;
+using VxFormGenerator.Form.Components.Plain;
+using VxFormGenerator.Models;
+
+namespace VxFormGenerator.Repository.Bulma
+{
+    public class VxBulmaRepository : FormGeneratorComponentModelBasedRepository
+    {
+        public VxBulmaRepository()
+        {
+            _ComponentDict = new Dictionary<Type, Type>()
+                  {
+                    { typeof(string),          typeof(InputText) },
+                    { typeof(DateTime),        typeof(InputDate<>) },
+                    { typeof(bool),            typeof(BulmaInputCheckbox) },
+                    { typeof(Enum),            typeof(BulmaInputSelectWithOptions<>) },
+                    { typeof(ValueReferences), typeof(BulmaInputCheckboxMultiple<>) },
+                    { typeof(decimal),         typeof(InputNumber<>) },
+                    { typeof(System.Single),   typeof(InputNumber<>) },
+                    { typeof(int),             typeof(InputNumber<>) },
+                    { typeof(VxColor),         typeof(InputColor) }
+                  };
+
+            _DefaultComponent = null;
+        }
+    }
+}

--- a/VxFormGenerator.Components.Bulma/VxBulmaFormCssClassProvider.cs
+++ b/VxFormGenerator.Components.Bulma/VxBulmaFormCssClassProvider.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace VxFormGenerator.Settings.Bulma
+{
+    public class VxBulmaFormCssClassProvider : VxFormCssClassProviderBase
+    {
+        public override VxFormCssClassAttribute CssClassAttribute { get => new VxFormCssClassAttribute() { Valid = "is-success", Invalid = "is-danger" }; }
+
+        public override string GetFieldCssClass(EditContext editContext, in FieldIdentifier fieldIdentifier)
+        {
+            return base.GetFieldCssClass(editContext, fieldIdentifier);
+        }
+    }
+}

--- a/VxFormGenerator.Components.Bulma/VxBulmaFormOptions.cs
+++ b/VxFormGenerator.Components.Bulma/VxBulmaFormOptions.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Components.Forms;
+using System;
+using VxFormGenerator.Core;
+using VxFormGenerator.Form;
+using VxFormGenerator.Render.Bulma;
+using VxFormGenerator.Render.Plain;
+
+namespace VxFormGenerator.Settings.Bulma
+{
+    public class VxBulmaFormOptions : IFormGeneratorOptions
+    {
+        public Type FormElementComponent { get; set; }
+
+        public FieldCssClassProvider FieldCssClassProvider { get; set; }
+
+        public Type FormGroupElement { get; set; }
+
+        public VxBulmaFormOptions()
+        {
+            FormElementComponent = typeof(BulmaFormElement<>);
+            FormGroupElement = typeof(VxFormGroup);
+            FieldCssClassProvider = new VxBulmaFormCssClassProvider();
+        }
+    }
+}

--- a/VxFormGenerator.Components.Bulma/VxBulmaFormServiceCollectionExtention.cs
+++ b/VxFormGenerator.Components.Bulma/VxBulmaFormServiceCollectionExtention.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.DependencyInjection;
+using VxFormGenerator.Repository.Bulma;
+
+namespace VxFormGenerator.Settings.Bulma
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static void AddVxFormGenerator(this IServiceCollection services, Core.Layout.VxFormLayoutOptions vxFormLayoutOptions = null, VxBulmaRepository repository = null, VxBulmaFormOptions options = null)
+        {
+            FormGeneratorServiceServiceCollectionExtension.AddVxFormGenerator(services,
+                vxFormLayoutOptions ?? new Core.Layout.VxFormLayoutOptions(),
+                repository ?? new VxBulmaRepository(),
+                options ?? new VxBulmaFormOptions()
+                );
+        }
+    }
+}

--- a/VxFormGenerator.Components.Bulma/VxFormGenerator.Components.Bulma.csproj
+++ b/VxFormGenerator.Components.Bulma/VxFormGenerator.Components.Bulma.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>0.4.0</Version>
+    <Authors>Alex Knijf</Authors>
+    <Copyright>Alex Knijf</Copyright>
+    <Company>Codershop</Company>
+    <Description>The Bulma styled form components for the VxFormGenerator</Description>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <PackageProjectUrl>https://github.com/Aaltuj/VxFormGenerator</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Aaltuj/VxFormGenerator</RepositoryUrl>
+    <RepositoryType>GIT</RepositoryType>
+    <PackageTags>Form generator, Blazor, Bulma, POCOS</PackageTags>
+    <PackageId>VxFormGenerator.Components.Bulma</PackageId>
+    <Product>VxFormGenerator.Components.Bulma</Product>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\VxFormGenerator.Core\README.md">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+    <Content Include="..\LICENSE.txt"
+             Link="LICENSE.txt"
+             Pack="true"
+             PackagePath="LICENSE.txt"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\VxFormGenerator.Components.Plain\VxFormGenerator.Components.Plain.csproj" />
+    <ProjectReference Include="..\VxFormGenerator.Core\VxFormGenerator.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/VxFormGenerator.Components.Tailwind/Components/TailwindInputCheckbox.cs
+++ b/VxFormGenerator.Components.Tailwind/Components/TailwindInputCheckbox.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using VxFormGenerator.Form.Components.Plain;
+
+namespace VxFormGenerator.Form.Components.Tailwind
+{
+    public class TailwindInputCheckbox : VxInputCheckbox
+    {
+        public TailwindInputCheckbox()
+        {
+            ContainerCss = "flex items-center gap-2";
+            AdditionalAttributes = new Dictionary<string, object>() { { "class", "h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500" } };
+            LabelCss = "text-sm font-medium text-gray-700";
+        }
+    }
+}

--- a/VxFormGenerator.Components.Tailwind/Components/TailwindInputCheckboxMultiple.cs
+++ b/VxFormGenerator.Components.Tailwind/Components/TailwindInputCheckboxMultiple.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Components.Rendering;
+using System.Collections.Generic;
+using VxFormGenerator.Core;
+using VxFormGenerator.Form.Components.Plain;
+
+namespace VxFormGenerator.Form.Components.Tailwind
+{
+    public class TailwindInputCheckboxMultiple<TValue> : InputCheckboxMultipleWithChildren<TValue>, IRenderChildren
+    {
+        public TailwindInputCheckboxMultiple()
+        {
+            AdditionalAttributes = new Dictionary<string, object>() { { "class", "space-y-2" } };
+        }
+
+        public new static void RenderChildren(RenderTreeBuilder builder,
+         int index,
+         object dataContext,
+         string fieldIdentifier)
+        {
+            RenderChildren(builder, index, dataContext, fieldIdentifier, typeof(TailwindInputCheckbox));
+        }
+    }
+}

--- a/VxFormGenerator.Components.Tailwind/Components/TailwindInputSelectWithOptions.cs
+++ b/VxFormGenerator.Components.Tailwind/Components/TailwindInputSelectWithOptions.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using VxFormGenerator.Form.Components.Plain;
+
+namespace VxFormGenerator.Form.Components.Tailwind
+{
+    public class TailwindInputSelectWithOptions<TValue> : InputSelectWithOptions<TValue>
+    {
+        public TailwindInputSelectWithOptions()
+        {
+            AdditionalAttributes = new Dictionary<string, object>() { { "class", "w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30" } };
+        }
+    }
+}

--- a/VxFormGenerator.Components.Tailwind/Render/TailwindFormElement.razor
+++ b/VxFormGenerator.Components.Tailwind/Render/TailwindFormElement.razor
@@ -1,0 +1,23 @@
+@namespace VxFormGenerator.Render.Tailwind
+
+@typeparam TFormElement
+@inherits TailwindFormElementComponent<TFormElement>
+
+@if (FieldTemplate != null)
+{
+    @FieldTemplate(CreateFieldTemplateContext("mt-1 text-sm text-red-600"))
+}
+else
+{
+    <div class="@CssClass">
+        @if (!string.IsNullOrWhiteSpace(FormColumnDefinition.RenderOptions.Label) && FormColumnDefinition.RenderOptions.ShowLabel)
+        {
+            <label class="mb-1 block text-sm font-medium text-gray-700" for="@Id">@FormColumnDefinition.RenderOptions.Label</label>
+        }
+
+        @CreateComponent()
+
+        <VxFormGenerator.Core.Validation.VxValidationMessage For="@ValueExpression" Class="mt-1 text-sm text-red-600">
+        </VxFormGenerator.Core.Validation.VxValidationMessage>
+    </div>
+}

--- a/VxFormGenerator.Components.Tailwind/Render/TailwindFormElement.razor.cs
+++ b/VxFormGenerator.Components.Tailwind/Render/TailwindFormElement.razor.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using VxFormGenerator.Core;
+
+namespace VxFormGenerator.Render.Tailwind
+{
+    public class TailwindFormElementComponent<TFormElement> : FormElementBase<TFormElement>
+    {
+        protected override void OnParametersSet()
+        {
+            base.OnParametersSet();
+
+            DefaultFieldClasses = new List<string>() { "w-full", "rounded-md", "border", "border-gray-300", "px-3", "py-2", "text-sm", "shadow-sm", "focus:border-blue-500", "focus:outline-none", "focus:ring-2", "focus:ring-blue-500/30" };
+            CssClasses = new List<string>() { "mb-4" };
+        }
+    }
+}

--- a/VxFormGenerator.Components.Tailwind/VxFormGenerator.Components.Tailwind.csproj
+++ b/VxFormGenerator.Components.Tailwind/VxFormGenerator.Components.Tailwind.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>0.4.0</Version>
+    <Authors>Alex Knijf</Authors>
+    <Copyright>Alex Knijf</Copyright>
+    <Company>Codershop</Company>
+    <Description>The Tailwind CSS styled form components for the VxFormGenerator</Description>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <PackageProjectUrl>https://github.com/Aaltuj/VxFormGenerator</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Aaltuj/VxFormGenerator</RepositoryUrl>
+    <RepositoryType>GIT</RepositoryType>
+    <PackageTags>Form generator, Blazor, Tailwind CSS, POCOS</PackageTags>
+    <PackageId>VxFormGenerator.Components.Tailwind</PackageId>
+    <Product>VxFormGenerator.Components.Tailwind</Product>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\VxFormGenerator.Core\README.md">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+    <Content Include="..\LICENSE.txt"
+             Link="LICENSE.txt"
+             Pack="true"
+             PackagePath="LICENSE.txt"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\VxFormGenerator.Components.Plain\VxFormGenerator.Components.Plain.csproj" />
+    <ProjectReference Include="..\VxFormGenerator.Core\VxFormGenerator.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/VxFormGenerator.Components.Tailwind/VxTailwindFormComponentsRepository.cs
+++ b/VxFormGenerator.Components.Tailwind/VxTailwindFormComponentsRepository.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Components.Forms;
+using System;
+using System.Collections.Generic;
+using VxFormGenerator.Core;
+using VxFormGenerator.Core.Repository;
+using VxFormGenerator.Form.Components.Plain;
+using VxFormGenerator.Form.Components.Tailwind;
+using VxFormGenerator.Models;
+
+namespace VxFormGenerator.Repository.Tailwind
+{
+    public class VxTailwindRepository : FormGeneratorComponentModelBasedRepository
+    {
+        public VxTailwindRepository()
+        {
+            _ComponentDict = new Dictionary<Type, Type>()
+                  {
+                    { typeof(string),          typeof(InputText) },
+                    { typeof(DateTime),        typeof(InputDate<>) },
+                    { typeof(bool),            typeof(TailwindInputCheckbox) },
+                    { typeof(Enum),            typeof(TailwindInputSelectWithOptions<>) },
+                    { typeof(ValueReferences), typeof(TailwindInputCheckboxMultiple<>) },
+                    { typeof(decimal),         typeof(InputNumber<>) },
+                    { typeof(System.Single),   typeof(InputNumber<>) },
+                    { typeof(int),             typeof(InputNumber<>) },
+                    { typeof(VxColor),         typeof(InputColor) }
+                  };
+
+            _DefaultComponent = null;
+        }
+    }
+}

--- a/VxFormGenerator.Components.Tailwind/VxTailwindFormCssClassProvider.cs
+++ b/VxFormGenerator.Components.Tailwind/VxTailwindFormCssClassProvider.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace VxFormGenerator.Settings.Tailwind
+{
+    public class VxTailwindFormCssClassProvider : VxFormCssClassProviderBase
+    {
+        public override VxFormCssClassAttribute CssClassAttribute { get => new VxFormCssClassAttribute() { Valid = "border-green-500 ring-green-500/30", Invalid = "border-red-500 ring-red-500/30" }; }
+
+        public override string GetFieldCssClass(EditContext editContext, in FieldIdentifier fieldIdentifier)
+        {
+            return base.GetFieldCssClass(editContext, fieldIdentifier);
+        }
+    }
+}

--- a/VxFormGenerator.Components.Tailwind/VxTailwindFormOptions.cs
+++ b/VxFormGenerator.Components.Tailwind/VxTailwindFormOptions.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Components.Forms;
+using System;
+using VxFormGenerator.Core;
+using VxFormGenerator.Form;
+using VxFormGenerator.Render.Plain;
+using VxFormGenerator.Render.Tailwind;
+
+namespace VxFormGenerator.Settings.Tailwind
+{
+    public class VxTailwindFormOptions : IFormGeneratorOptions
+    {
+        public Type FormElementComponent { get; set; }
+
+        public FieldCssClassProvider FieldCssClassProvider { get; set; }
+
+        public Type FormGroupElement { get; set; }
+
+        public VxTailwindFormOptions()
+        {
+            FormElementComponent = typeof(TailwindFormElement<>);
+            FormGroupElement = typeof(VxFormGroup);
+            FieldCssClassProvider = new VxTailwindFormCssClassProvider();
+        }
+    }
+}

--- a/VxFormGenerator.Components.Tailwind/VxTailwindFormServiceCollectionExtention.cs
+++ b/VxFormGenerator.Components.Tailwind/VxTailwindFormServiceCollectionExtention.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.DependencyInjection;
+using VxFormGenerator.Repository.Tailwind;
+
+namespace VxFormGenerator.Settings.Tailwind
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static void AddVxFormGenerator(this IServiceCollection services, Core.Layout.VxFormLayoutOptions vxFormLayoutOptions = null, VxTailwindRepository repository = null, VxTailwindFormOptions options = null)
+        {
+            FormGeneratorServiceServiceCollectionExtension.AddVxFormGenerator(services,
+                vxFormLayoutOptions ?? new Core.Layout.VxFormLayoutOptions(),
+                repository ?? new VxTailwindRepository(),
+                options ?? new VxTailwindFormOptions()
+                );
+        }
+    }
+}

--- a/VxFormGenerator.Core.Tests/DynamicFormRouteTests.cs
+++ b/VxFormGenerator.Core.Tests/DynamicFormRouteTests.cs
@@ -22,6 +22,47 @@ namespace VxFormGenerator.Core.Tests
         }
 
         [Fact]
+        public void HomePage_LinksToUiRendererDemos()
+        {
+            var component = Render<VxFormGeneratorDemo.Shared.Pages.Index>();
+
+            Assert.Contains("Bulma renderer", component.Markup);
+            Assert.Contains("href=\"bulma-form\"", component.Markup);
+            Assert.Contains("Tailwind renderer", component.Markup);
+            Assert.Contains("href=\"tailwind-form\"", component.Markup);
+        }
+
+        [Fact]
+        public void BulmaForm_RendersBulmaDemoStyles()
+        {
+            global::VxFormGenerator.Settings.Bulma.ServiceCollectionExtensions.AddVxFormGenerator(Services);
+
+            var component = Render<BulmaForm>();
+
+            Assert.Contains("Bulma Renderer Demo", component.Markup);
+            Assert.Contains("class=\"box\"", component.Markup);
+            Assert.Contains("class=\"button is-primary\"", component.Markup);
+            Assert.Contains("class=\"field\"", component.Markup);
+            Assert.Contains("input", component.Find("input:not([type])").ClassList);
+            Assert.Contains("select", component.Find("select").ClassList);
+        }
+
+        [Fact]
+        public void TailwindForm_RendersTailwindDemoStyles()
+        {
+            global::VxFormGenerator.Settings.Tailwind.ServiceCollectionExtensions.AddVxFormGenerator(Services);
+
+            var component = Render<TailwindForm>();
+
+            Assert.Contains("Tailwind Renderer Demo", component.Markup);
+            Assert.Contains("rounded-lg border border-gray-200 bg-white p-6 shadow-sm", component.Markup);
+            Assert.Contains("rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white", component.Markup);
+            Assert.Contains("mb-4", component.Find("input:not([type])").ParentElement.GetAttribute("class"));
+            Assert.Contains("w-full", component.Find("input:not([type])").ClassList);
+            Assert.Contains("w-full", component.Find("select").ClassList);
+        }
+
+        [Fact]
         public void DynamicForm_RendersMetadataGeneratedForm()
         {
             var component = Render<DynamicForm>();

--- a/VxFormGenerator.Core.Tests/UiRendererPackageTests.cs
+++ b/VxFormGenerator.Core.Tests/UiRendererPackageTests.cs
@@ -1,0 +1,102 @@
+using System;
+using Bunit;
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.Extensions.DependencyInjection;
+using VxFormGenerator.Core;
+using VxFormGenerator.Form.Components.Bulma;
+using VxFormGenerator.Form.Components.Tailwind;
+using VxFormGenerator.Render.Bulma;
+using VxFormGenerator.Render.Tailwind;
+using VxFormGenerator.Repository.Bulma;
+using VxFormGenerator.Repository.Tailwind;
+using VxFormGenerator.Settings.Bulma;
+using VxFormGenerator.Settings.Tailwind;
+using Xunit;
+
+namespace VxFormGenerator.Core.Tests
+{
+    public class UiRendererPackageTests : BunitContext
+    {
+        [Fact]
+        public void BulmaOptionsUseBulmaRendererAndValidationClasses()
+        {
+            var options = new VxBulmaFormOptions();
+
+            Assert.Equal(typeof(BulmaFormElement<>), options.FormElementComponent);
+
+            var provider = Assert.IsType<VxBulmaFormCssClassProvider>(options.FieldCssClassProvider);
+            Assert.Equal("is-success", provider.CssClassAttribute.Valid);
+            Assert.Equal("is-danger", provider.CssClassAttribute.Invalid);
+        }
+
+        [Fact]
+        public void TailwindOptionsUseTailwindRendererAndValidationClasses()
+        {
+            var options = new VxTailwindFormOptions();
+
+            Assert.Equal(typeof(TailwindFormElement<>), options.FormElementComponent);
+
+            var provider = Assert.IsType<VxTailwindFormCssClassProvider>(options.FieldCssClassProvider);
+            Assert.Contains("border-green-500", provider.CssClassAttribute.Valid);
+            Assert.Contains("border-red-500", provider.CssClassAttribute.Invalid);
+        }
+
+        [Fact]
+        public void BulmaRepositoryMapsCoreFieldTypesToBulmaComponents()
+        {
+            var repository = new VxBulmaRepository();
+
+            Assert.Equal(typeof(InputText), repository.GetComponent(typeof(string)));
+            Assert.Equal(typeof(BulmaInputCheckbox), repository.GetComponent(typeof(bool)));
+            Assert.Equal(typeof(BulmaInputSelectWithOptions<>), repository.GetComponent(typeof(DemoChoice)));
+            Assert.Equal(typeof(BulmaInputCheckboxMultiple<>), repository.GetComponent(typeof(ValueReferences)));
+        }
+
+        [Fact]
+        public void TailwindRepositoryMapsCoreFieldTypesToTailwindComponents()
+        {
+            var repository = new VxTailwindRepository();
+
+            Assert.Equal(typeof(InputText), repository.GetComponent(typeof(string)));
+            Assert.Equal(typeof(TailwindInputCheckbox), repository.GetComponent(typeof(bool)));
+            Assert.Equal(typeof(TailwindInputSelectWithOptions<>), repository.GetComponent(typeof(DemoChoice)));
+            Assert.Equal(typeof(TailwindInputCheckboxMultiple<>), repository.GetComponent(typeof(ValueReferences)));
+        }
+
+
+
+        [Fact]
+        public void BulmaRendererUsesTextInputDefaultsOnlyForPlainInputComponents()
+        {
+            global::VxFormGenerator.Settings.Bulma.ServiceCollectionExtensions.AddVxFormGenerator(Services);
+
+            var component = Render<UiRendererTestHost>();
+
+            Assert.Contains("input", component.Find("input[type='text']").ClassList);
+            Assert.Contains("input", component.Find("input[type='number']").ClassList);
+            Assert.DoesNotContain("input", component.Find("input[type='checkbox']").ClassList);
+            Assert.Contains("checkbox", component.Find("input[type='checkbox']").ClassList);
+            Assert.Contains("select", component.Find("select").ClassList);
+        }
+
+        [Fact]
+        public void TailwindRendererUsesTextInputDefaultsOnlyForPlainInputComponents()
+        {
+            global::VxFormGenerator.Settings.Tailwind.ServiceCollectionExtensions.AddVxFormGenerator(Services);
+
+            var component = Render<UiRendererTestHost>();
+
+            Assert.Contains("w-full", component.Find("input[type='text']").ClassList);
+            Assert.Contains("w-full", component.Find("input[type='number']").ClassList);
+            Assert.DoesNotContain("w-full", component.Find("input[type='checkbox']").ClassList);
+            Assert.Contains("h-4", component.Find("input[type='checkbox']").ClassList);
+            Assert.Contains("w-full", component.Find("select").ClassList);
+        }
+
+        private enum DemoChoice
+        {
+            First,
+            Second
+        }
+    }
+}

--- a/VxFormGenerator.Core.Tests/UiRendererPackageTests.cs
+++ b/VxFormGenerator.Core.Tests/UiRendererPackageTests.cs
@@ -72,7 +72,7 @@ namespace VxFormGenerator.Core.Tests
 
             var component = Render<UiRendererTestHost>();
 
-            Assert.Contains("input", component.Find("input[type='text']").ClassList);
+            Assert.Contains("input", component.Find("input:not([type])").ClassList);
             Assert.Contains("input", component.Find("input[type='number']").ClassList);
             Assert.DoesNotContain("input", component.Find("input[type='checkbox']").ClassList);
             Assert.Contains("checkbox", component.Find("input[type='checkbox']").ClassList);
@@ -86,7 +86,7 @@ namespace VxFormGenerator.Core.Tests
 
             var component = Render<UiRendererTestHost>();
 
-            Assert.Contains("w-full", component.Find("input[type='text']").ClassList);
+            Assert.Contains("w-full", component.Find("input:not([type])").ClassList);
             Assert.Contains("w-full", component.Find("input[type='number']").ClassList);
             Assert.DoesNotContain("w-full", component.Find("input[type='checkbox']").ClassList);
             Assert.Contains("h-4", component.Find("input[type='checkbox']").ClassList);

--- a/VxFormGenerator.Core.Tests/UiRendererTestHost.razor
+++ b/VxFormGenerator.Core.Tests/UiRendererTestHost.razor
@@ -1,0 +1,29 @@
+@using System.ComponentModel.DataAnnotations
+@using Microsoft.AspNetCore.Components.Forms
+@using VxFormGenerator.Core
+
+<EditForm Model="Model">
+    <RenderFormElements />
+</EditForm>
+
+@code {
+    public UiRendererModel Model { get; } = new UiRendererModel();
+
+    public class UiRendererModel
+    {
+        [Required]
+        public string Name { get; set; }
+
+        public bool Enabled { get; set; }
+
+        public UiRendererChoice Choice { get; set; }
+
+        public int Quantity { get; set; }
+    }
+
+    public enum UiRendererChoice
+    {
+        First,
+        Second
+    }
+}

--- a/VxFormGenerator.Core.Tests/VxFormGenerator.Core.Tests.csproj
+++ b/VxFormGenerator.Core.Tests/VxFormGenerator.Core.Tests.csproj
@@ -21,6 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\VxFormGenerator.Components.Bulma\VxFormGenerator.Components.Bulma.csproj" />
+    <ProjectReference Include="..\VxFormGenerator.Components.Tailwind\VxFormGenerator.Components.Tailwind.csproj" />
     <ProjectReference Include="..\VxFormGenerator.Core\VxFormGenerator.Core.csproj" />
     <ProjectReference Include="..\VxFormGeneratorDemo.Shared\VxFormGeneratorDemo.Shared.csproj" />
     <ProjectReference Include="..\VxFormGeneratorDemoData\VxFormGeneratorDemoData.csproj" />

--- a/VxFormGenerator.Core/FormElementBase.cs
+++ b/VxFormGenerator.Core/FormElementBase.cs
@@ -198,7 +198,7 @@ namespace VxFormGenerator.Core
                   AdditionalAttributes.TryGetValue("class", out var @class) &&
                   !string.IsNullOrEmpty(Convert.ToString(@class)))
             {
-                return $"{@class} {output}";
+                return Convert.ToString(@class);
             }
 
             return output;

--- a/VxFormGenerator.Core/README.md
+++ b/VxFormGenerator.Core/README.md
@@ -3,7 +3,20 @@
 This library is sprout of a POC I've created for an [article](https://github.com/Aaltuj/VxFormGenerator). Based on that work and the improvements made in this [article](https://medium.com/@aaltuj/simple-to-use-dynamic-form-generator-powered-by-blazor-c38a068576e7), I decided to publish it a as [NuGet](https://www.nuget.org/packages/VxFormGenerator/0.0.3) package.
 
 > Be aware that the current state is not ready for production, use it AT YOUR OWN RISK. Also to fully style all the built-in Blazor components it's recommended that you wait for [this pull request](https://github.com/dotnet/aspnetcore/pull/24835) for the `aspnetcore` repo to be merged and released. Allowing use to implement custom Validation classes. The current state of the library has a ugly workaround.
+### UI component packages
 
+Choose one renderer package for the CSS framework used by the host app:
+
+```bash
+dotnet add package VxFormGenerator.Components.Plain
+dotnet add package VxFormGenerator.Components.Bootstrap
+dotnet add package VxFormGenerator.Components.Bulma
+dotnet add package VxFormGenerator.Components.Tailwind
+```
+
+The styled packages add framework-specific classes to generated fields. The host app remains responsible for loading Bootstrap, Bulma, or Tailwind CSS. Register the matching namespace before calling `AddVxFormGenerator`, for example `VxFormGenerator.Settings.Bulma` or `VxFormGenerator.Settings.Tailwind`.
+
+For Tailwind, include the renderer package and your app markup in the Tailwind content scan or safelist the renderer utilities. The demo uses a checked-in prebuilt stylesheet at `_content/VxFormGeneratorDemo.Shared/css/tailwind/vxform-tailwind.css`; production apps should generate an equivalent stylesheet from their Tailwind build.
 
 
 ### Usage

--- a/VxFormGeneratorDemo.Server/Pages/_Host.cshtml
+++ b/VxFormGeneratorDemo.Server/Pages/_Host.cshtml
@@ -13,6 +13,8 @@
     <title>FormGeneratorDemo</title>
     <base href="~/" />
     <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
+    <link rel="stylesheet" href="_content/VxFormGeneratorDemo.Shared/css/bulma/vxform-bulma.css" />
+    <link rel="stylesheet" href="_content/VxFormGeneratorDemo.Shared/css/tailwind/vxform-tailwind.css" />
     <link href="css/site.css" rel="stylesheet" />
 </head>
 <body>

--- a/VxFormGeneratorDemo.Server/Program.cs
+++ b/VxFormGeneratorDemo.Server/Program.cs
@@ -3,7 +3,11 @@ using Microsoft.AspNetCore.Localization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-#if BOOTSTRAP
+#if BULMA
+using VxFormGenerator.Settings.Bulma;
+#elif TAILWIND
+using VxFormGenerator.Settings.Tailwind;
+#elif BOOTSTRAP
 using VxFormGenerator.Settings.Bootstrap;
 #else
 using VxFormGenerator.Settings.Plain;

--- a/VxFormGeneratorDemo.Server/Startup.cs
+++ b/VxFormGeneratorDemo.Server/Startup.cs
@@ -6,7 +6,11 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-#if BOOTSTRAP
+#if BULMA
+ using VxFormGenerator.Settings.Bulma;
+#elif TAILWIND
+ using VxFormGenerator.Settings.Tailwind;
+#elif BOOTSTRAP
  using VxFormGenerator.Settings.Bootstrap;
 #else
  using VxFormGenerator.Settings.Plain;

--- a/VxFormGeneratorDemo.Server/VxFormGeneratorDemo.Server.csproj
+++ b/VxFormGeneratorDemo.Server/VxFormGeneratorDemo.Server.csproj
@@ -14,6 +14,14 @@
     <DefineConstants>TRACE; BOOTSTRAP;</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)'=='Bulma'">
+    <DefineConstants>TRACE; BULMA;</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Tailwind'">
+    <DefineConstants>TRACE; TAILWIND;</DefineConstants>
+  </PropertyGroup>
+
 
   <ItemGroup>
     <Compile Remove="Components\**" />
@@ -23,7 +31,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\VxFormGenerator.Components.Bulma\VxFormGenerator.Components.Bulma.csproj" />
     <ProjectReference Include="..\VxFormGenerator.Components.Bootstrap\VxFormGenerator.Components.Bootstrap.csproj" />
+    <ProjectReference Include="..\VxFormGenerator.Components.Tailwind\VxFormGenerator.Components.Tailwind.csproj" />
     <ProjectReference Include="..\VxFormGenerator.Components.Plain\VxFormGenerator.Components.Plain.csproj" />
     <ProjectReference Include="..\VxFormGeneratorDemo.Shared\VxFormGeneratorDemo.Shared.csproj" />
     <ProjectReference Include="..\VxFormGeneratorDemoData\VxFormGeneratorDemoData.csproj" />

--- a/VxFormGeneratorDemo.Shared/Pages/BulmaForm.razor
+++ b/VxFormGeneratorDemo.Shared/Pages/BulmaForm.razor
@@ -1,0 +1,68 @@
+@page "/bulma-form"
+
+@using System
+@using System.ComponentModel.DataAnnotations
+@using VxFormGenerator.Core
+
+<h1>Bulma Renderer Demo</h1>
+
+<div class="box">
+    <h5 class="title is-5">Package registration</h5>
+    <p class="content">
+        Compile the demo with the <code>BULMA</code> symbol to use <code>VxFormGenerator.Components.Bulma</code> for generated forms.
+    </p>
+
+    <EditForm Model="Model" OnValidSubmit="HandleValidSubmit">
+        <VxFormGenerator.Core.Validation.ObjectGraphDataAnnotationsValidator />
+        <RenderFormElements></RenderFormElements>
+        <button class="button is-primary" type="submit">Submit</button>
+    </EditForm>
+
+    @if (Submitted)
+    {
+        <p class="notification is-success is-light">Submitted @Model.Name for @Model.FoodKind.</p>
+    }
+</div>
+
+@code {
+    private BulmaDemoModel Model { get; } = new BulmaDemoModel();
+
+    private bool Submitted { get; set; }
+
+    private void HandleValidSubmit()
+    {
+        Submitted = true;
+    }
+
+    public class BulmaDemoModel
+    {
+        [Required]
+        [Display(Name = "Session name", Prompt = "Morning feeding")]
+        public string Name { get; set; }
+
+        [Display(Name = "Food kind")]
+        public BulmaFoodKind FoodKind { get; set; }
+
+        [Range(0, 1000)]
+        [Display(Name = "Amount")]
+        public decimal Amount { get; set; }
+
+        [Display(Name = "Served on")]
+        public DateTime ServedOn { get; set; } = DateTime.Today;
+
+        [Display(Name = "Options")]
+        public ValueReferences Options { get; set; } = new ValueReferences
+        {
+            new ValueReference<string, bool> { Key = "Warmed", Value = true },
+            new ValueReference<string, bool> { Key = "Prepared ahead", Value = false },
+            new ValueReference<string, bool> { Key = "Needs follow-up", Value = false }
+        };
+    }
+
+    public enum BulmaFoodKind
+    {
+        Bottle,
+        Solid,
+        Other
+    }
+}

--- a/VxFormGeneratorDemo.Shared/Pages/Index.razor
+++ b/VxFormGeneratorDemo.Shared/Pages/Index.razor
@@ -32,4 +32,22 @@
             </div>
         </div>
     </div>
+    <div class="col-sm-4 mt-3">
+        <div class="card">
+            <div class="card-body">
+                <h5 class="card-title">Bulma renderer</h5>
+                <p class="card-text">Preview forms rendered with Bulma class conventions</p>
+                <a href="bulma-form" class="btn btn-primary">Go to demo</a>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-4 mt-3">
+        <div class="card">
+            <div class="card-body">
+                <h5 class="card-title">Tailwind renderer</h5>
+                <p class="card-text">Preview forms rendered with Tailwind utility classes</p>
+                <a href="tailwind-form" class="btn btn-primary">Go to demo</a>
+            </div>
+        </div>
+    </div>
 </div>

--- a/VxFormGeneratorDemo.Shared/Pages/TailwindForm.razor
+++ b/VxFormGeneratorDemo.Shared/Pages/TailwindForm.razor
@@ -1,0 +1,68 @@
+@page "/tailwind-form"
+
+@using System
+@using System.ComponentModel.DataAnnotations
+@using VxFormGenerator.Core
+
+<h1>Tailwind Renderer Demo</h1>
+
+<div class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+    <h5 class="text-lg font-semibold text-gray-900">Package registration</h5>
+    <p class="mb-4 text-sm text-gray-600">
+        Compile the demo with the <code>TAILWIND</code> symbol to use <code>VxFormGenerator.Components.Tailwind</code> for generated forms.
+    </p>
+
+    <EditForm Model="Model" OnValidSubmit="HandleValidSubmit">
+        <VxFormGenerator.Core.Validation.ObjectGraphDataAnnotationsValidator />
+        <RenderFormElements></RenderFormElements>
+        <button class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white" type="submit">Submit</button>
+    </EditForm>
+
+    @if (Submitted)
+    {
+        <p class="rounded-md bg-green-50 p-3 text-sm text-green-700">Submitted @Model.Name for @Model.FoodKind.</p>
+    }
+</div>
+
+@code {
+    private TailwindDemoModel Model { get; } = new TailwindDemoModel();
+
+    private bool Submitted { get; set; }
+
+    private void HandleValidSubmit()
+    {
+        Submitted = true;
+    }
+
+    public class TailwindDemoModel
+    {
+        [Required]
+        [Display(Name = "Session name", Prompt = "Morning feeding")]
+        public string Name { get; set; }
+
+        [Display(Name = "Food kind")]
+        public TailwindFoodKind FoodKind { get; set; }
+
+        [Range(0, 1000)]
+        [Display(Name = "Amount")]
+        public decimal Amount { get; set; }
+
+        [Display(Name = "Served on")]
+        public DateTime ServedOn { get; set; } = DateTime.Today;
+
+        [Display(Name = "Options")]
+        public ValueReferences Options { get; set; } = new ValueReferences
+        {
+            new ValueReference<string, bool> { Key = "Warmed", Value = true },
+            new ValueReference<string, bool> { Key = "Prepared ahead", Value = false },
+            new ValueReference<string, bool> { Key = "Needs follow-up", Value = false }
+        };
+    }
+
+    public enum TailwindFoodKind
+    {
+        Bottle,
+        Solid,
+        Other
+    }
+}

--- a/VxFormGeneratorDemo.Shared/Shared/NavMenu.razor
+++ b/VxFormGeneratorDemo.Shared/Shared/NavMenu.razor
@@ -25,6 +25,16 @@
             </NavLink>
         </li>
         <li class="nav-item px-3">
+            <NavLink class="nav-link" href="bulma-form" Match="NavLinkMatch.All">
+                <span class="oi oi-list-rich" aria-hidden="true"></span> Bulma renderer
+            </NavLink>
+        </li>
+        <li class="nav-item px-3">
+            <NavLink class="nav-link" href="tailwind-form" Match="NavLinkMatch.All">
+                <span class="oi oi-spreadsheet" aria-hidden="true"></span> Tailwind renderer
+            </NavLink>
+        </li>
+        <li class="nav-item px-3">
             <NavLink class="nav-link" href="custom-field-template" Match="NavLinkMatch.All">
                 <span class="oi oi-layers" aria-hidden="true"></span> Custom field template
             </NavLink>

--- a/VxFormGeneratorDemo.Shared/VxFormGeneratorDemo.Shared.csproj
+++ b/VxFormGeneratorDemo.Shared/VxFormGeneratorDemo.Shared.csproj
@@ -11,8 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\VxFormGenerator.Components.Bulma\VxFormGenerator.Components.Bulma.csproj" />
     <ProjectReference Include="..\VxFormGenerator.Components.Bootstrap\VxFormGenerator.Components.Bootstrap.csproj" />
     <ProjectReference Include="..\VxFormGenerator.Components.Plain\VxFormGenerator.Components.Plain.csproj" />
+    <ProjectReference Include="..\VxFormGenerator.Components.Tailwind\VxFormGenerator.Components.Tailwind.csproj" />
     <ProjectReference Include="..\VxFormGeneratorDemoData\VxFormGeneratorDemoData.csproj" />
   </ItemGroup>
   

--- a/VxFormGeneratorDemo.Shared/wwwroot/css/bulma/vxform-bulma.css
+++ b/VxFormGeneratorDemo.Shared/wwwroot/css/bulma/vxform-bulma.css
@@ -1,0 +1,77 @@
+.field:not(:last-child) {
+    margin-bottom: .75rem;
+}
+
+.label {
+    color: #363636;
+    display: block;
+    font-size: 1rem;
+    font-weight: 700;
+    margin-bottom: .5rem;
+}
+
+.control {
+    box-sizing: border-box;
+    clear: both;
+    font-size: 1rem;
+    position: relative;
+    text-align: inherit;
+}
+
+.input,
+.select {
+    appearance: none;
+    align-items: center;
+    background-color: #fff;
+    border: 1px solid #dbdbdb;
+    border-radius: 4px;
+    box-shadow: inset 0 .0625em .125em rgba(10, 10, 10, .05);
+    color: #363636;
+    display: inline-flex;
+    font-size: 1rem;
+    height: 2.5em;
+    justify-content: flex-start;
+    line-height: 1.5;
+    padding: calc(.5em - 1px) calc(.75em - 1px);
+    position: relative;
+    vertical-align: top;
+}
+
+.input:focus,
+.select:focus {
+    border-color: #485fc7;
+    box-shadow: 0 0 0 .125em rgba(72, 95, 199, .25);
+    outline: 0;
+}
+
+.select.is-fullwidth,
+.select.is-fullwidth select,
+.input {
+    width: 100%;
+}
+
+.checkbox {
+    cursor: pointer;
+    display: inline-block;
+    line-height: 1.25;
+    position: relative;
+}
+
+.checkbox input {
+    cursor: pointer;
+    margin-right: .5em;
+}
+
+.help {
+    display: block;
+    font-size: .75rem;
+    margin-top: .25rem;
+}
+
+.is-success {
+    border-color: #48c78e;
+}
+
+.is-danger {
+    border-color: #f14668;
+}

--- a/VxFormGeneratorDemo.Shared/wwwroot/css/bulma/vxform-bulma.css
+++ b/VxFormGeneratorDemo.Shared/wwwroot/css/bulma/vxform-bulma.css
@@ -2,6 +2,30 @@
     margin-bottom: .75rem;
 }
 
+.box {
+    background-color: #fff;
+    border-radius: 6px;
+    box-shadow: 0 .5em 1em -.125em rgba(10, 10, 10, .1), 0 0 0 1px rgba(10, 10, 10, .02);
+    color: #4a4a4a;
+    display: block;
+    padding: 1.25rem;
+}
+
+.content:not(:last-child),
+.title:not(:last-child) {
+    margin-bottom: 1rem;
+}
+
+.title {
+    color: #363636;
+    font-weight: 600;
+    line-height: 1.125;
+}
+
+.title.is-5 {
+    font-size: 1.25rem;
+}
+
 .label {
     color: #363636;
     display: block;
@@ -68,8 +92,49 @@
     margin-top: .25rem;
 }
 
+.button {
+    align-items: center;
+    background-color: #fff;
+    border: 1px solid #dbdbdb;
+    border-radius: 4px;
+    box-shadow: none;
+    color: #363636;
+    cursor: pointer;
+    display: inline-flex;
+    font-size: 1rem;
+    height: 2.5em;
+    justify-content: center;
+    line-height: 1.5;
+    padding: calc(.5em - 1px) 1em;
+    text-align: center;
+    vertical-align: top;
+}
+
+.button.is-primary {
+    background-color: #00d1b2;
+    border-color: transparent;
+    color: #fff;
+}
+
+.notification {
+    border-radius: 4px;
+    margin-top: 1rem;
+    padding: 1.25rem 2.5rem 1.25rem 1.5rem;
+    position: relative;
+}
+
 .is-success {
     border-color: #48c78e;
+}
+
+.notification.is-success {
+    background-color: #48c78e;
+    color: #fff;
+}
+
+.notification.is-success.is-light {
+    background-color: #effaf5;
+    color: #257953;
 }
 
 .is-danger {

--- a/VxFormGeneratorDemo.Shared/wwwroot/css/tailwind/vxform-tailwind.css
+++ b/VxFormGeneratorDemo.Shared/wwwroot/css/tailwind/vxform-tailwind.css
@@ -1,0 +1,67 @@
+/*
+   Prebuilt Tailwind demo CSS generated for the utility classes emitted by
+   VxFormGenerator.Components.Tailwind and the Tailwind demo page.
+*/
+*, ::before, ::after {
+    box-sizing: border-box;
+    border-width: 0;
+    border-style: solid;
+    border-color: #e5e7eb;
+}
+
+button,
+input,
+select {
+    font: inherit;
+}
+
+.mb-1 { margin-bottom: .25rem; }
+.mb-4 { margin-bottom: 1rem; }
+.mt-1 { margin-top: .25rem; }
+.block { display: block; }
+.flex { display: flex; }
+.h-4 { height: 1rem; }
+.w-4 { width: 1rem; }
+.w-full { width: 100%; }
+.items-center { align-items: center; }
+.gap-2 { gap: .5rem; }
+.space-y-2 > :not([hidden]) ~ :not([hidden]) { margin-top: .5rem; }
+.rounded { border-radius: .25rem; }
+.rounded-lg { border-radius: .5rem; }
+.rounded-md { border-radius: .375rem; }
+.border { border-width: 1px; }
+.border-gray-200 { border-color: #e5e7eb; }
+.border-gray-300 { border-color: #d1d5db; }
+.border-green-500 { border-color: #22c55e; }
+.border-red-500 { border-color: #ef4444; }
+.bg-blue-600 { background-color: #2563eb; }
+.bg-green-50 { background-color: #f0fdf4; }
+.bg-white { background-color: #fff; }
+.p-3 { padding: .75rem; }
+.p-6 { padding: 1.5rem; }
+.px-3 { padding-left: .75rem; padding-right: .75rem; }
+.px-4 { padding-left: 1rem; padding-right: 1rem; }
+.py-2 { padding-top: .5rem; padding-bottom: .5rem; }
+.text-sm { font-size: .875rem; line-height: 1.25rem; }
+.text-lg { font-size: 1.125rem; line-height: 1.75rem; }
+.font-medium { font-weight: 500; }
+.font-semibold { font-weight: 600; }
+.text-blue-600 { color: #2563eb; }
+.text-gray-600 { color: #4b5563; }
+.text-gray-700 { color: #374151; }
+.text-gray-900 { color: #111827; }
+.text-green-700 { color: #15803d; }
+.text-red-600 { color: #dc2626; }
+.text-white { color: #fff; }
+.shadow-sm { box-shadow: 0 1px 2px 0 rgba(0, 0, 0, .05); }
+.ring-green-500\/30 { box-shadow: 0 0 0 3px rgba(34, 197, 94, .3); }
+.ring-red-500\/30 { box-shadow: 0 0 0 3px rgba(239, 68, 68, .3); }
+.focus\:border-blue-500:focus { border-color: #3b82f6; }
+.focus\:outline-none:focus { outline: 2px solid transparent; outline-offset: 2px; }
+.focus\:ring-2:focus { box-shadow: 0 0 0 2px rgba(59, 130, 246, .5); }
+.focus\:ring-blue-500\/30:focus { box-shadow: 0 0 0 3px rgba(59, 130, 246, .3); }
+
+select.w-full,
+input.w-full {
+    display: block;
+}

--- a/VxFormGeneratorDemo.Wasm/Program.cs
+++ b/VxFormGeneratorDemo.Wasm/Program.cs
@@ -7,8 +7,12 @@ using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-#if BOOTSTRAP
- using VxFormGenerator.Settings.Bootstrap;
+#if BULMA
+using VxFormGenerator.Settings.Bulma;
+#elif TAILWIND
+using VxFormGenerator.Settings.Tailwind;
+#elif BOOTSTRAP
+using VxFormGenerator.Settings.Bootstrap;
 #else
 using VxFormGenerator.Settings.Plain;
 #endif

--- a/VxFormGeneratorDemo.Wasm/VxFormGeneratorDemo.Wasm.csproj
+++ b/VxFormGeneratorDemo.Wasm/VxFormGeneratorDemo.Wasm.csproj
@@ -4,13 +4,27 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)'=='Bootstrap'">
+    <DefineConstants>TRACE; BOOTSTRAP;</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Bulma'">
+    <DefineConstants>TRACE; BULMA;</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Tailwind'">
+    <DefineConstants>TRACE; TAILWIND;</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\VxFormGenerator.Components.Bulma\VxFormGenerator.Components.Bulma.csproj" />
     <ProjectReference Include="..\VxFormGenerator.Components.Bootstrap\VxFormGenerator.Components.Bootstrap.csproj" />
+    <ProjectReference Include="..\VxFormGenerator.Components.Tailwind\VxFormGenerator.Components.Tailwind.csproj" />
     <ProjectReference Include="..\VxFormGeneratorDemo.Shared\VxFormGeneratorDemo.Shared.csproj" />
     <ProjectReference Include="..\VxFormGeneratorDemoData\VxFormGeneratorDemoData.csproj" />
   </ItemGroup>

--- a/VxFormGeneratorDemo.Wasm/wwwroot/index.html
+++ b/VxFormGeneratorDemo.Wasm/wwwroot/index.html
@@ -7,6 +7,8 @@
     <title>VxFormGeneratorDemo.Wasm</title>
     <base href="/" />
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
+    <link href="_content/VxFormGeneratorDemo.Shared/css/bulma/vxform-bulma.css" rel="stylesheet" />
+    <link href="_content/VxFormGeneratorDemo.Shared/css/tailwind/vxform-tailwind.css" rel="stylesheet" />
     <link href="css/app.css" rel="stylesheet" />
     <link href="VxFormGeneratorDemo.Wasm.styles.css" rel="stylesheet" />
 </head>


### PR DESCRIPTION
## Summary
- Add dedicated Bulma and Tailwind renderer packages matching the existing Bootstrap package shape.
- Add Bulma and Tailwind demo routes, nav links, conditional DI registration, and shared static CSS assets for the demos.
- Use a checked-in prebuilt Tailwind demo stylesheet instead of a CDN/demo-only script, and document the production Tailwind content/safelist requirement.
- Prevent framework text-input defaults from being appended to component-specific checkbox/select controls and add bUnit coverage for that behavior.

## Verification
- `git diff --check`
- `git diff --cached --check`
- Static search confirmed no `cdn.tailwind`, `tailwindcss.com`, `unpkg.com`, or `jsdelivr` references in the demo/package/doc paths.

## Verification not run
- Devcontainer restore/build/test could not be run in this Paperclip runtime because no `docker`, `podman`, or `devcontainer` CLI is installed.
- Local fallback could not be run because no `dotnet` is on `PATH` and `/workspace/.dotnet/dotnet` does not exist.

## Notes
- Git metadata in this checkout had root-owned object shards, so the commit was created with a writable alternate object store configured under `.git/objects-node`.
